### PR TITLE
linker: allow text relocations on user builds

### DIFF
--- a/linker/Android.mk
+++ b/linker/Android.mk
@@ -55,11 +55,7 @@ LOCAL_CPPFLAGS += -DTARGET_IS_64_BIT
 endif
 
 ifeq ($(TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS),true)
-ifeq ($(user_variant),user)
-$(error Do not enable text relocations on user builds)
-else
 LOCAL_CPPFLAGS += -DTARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS
-endif
 endif
 
 # We need to access Bionic private headers in the linker.


### PR DESCRIPTION
* This check was originally added to prevent this flag
  from making it in to production builds at inc. We're
  not shipping any production builds and in the interest
  of security regarding userdebug vs user, adb root for
  example, allow building with this flag on more secure
  builds.

Change-Id: Ie80706e64aaef5b91e59abf926d62c3ba60a5396