### PR TITLE
linker: Allow devices to force shim libs

### DIFF
--- a/linker/Android.mk
+++ b/linker/Android.mk
@@ -65,6 +65,10 @@ ifneq ($(LINKER_NON_PIE_EXECUTABLES_HEADER_DIR),)
     LOCAL_SRC_FILES += linker_non_pie.cpp
 endif
 
+ifneq ($(LINKER_FORCED_SHIM_LIBS),)
+    LOCAL_CFLAGS += -DFORCED_SHIM_LIBS="\"$(LINKER_FORCED_SHIM_LIBS)\""
+endif
+
 # we don't want crtbegin.o (because we have begin.o), so unset it
 # just for this module
 LOCAL_NO_CRT := true

--- a/linker/linker.cpp
+++ b/linker/linker.cpp
@@ -1258,8 +1258,7 @@ static void reset_g_active_shim_libs(void) {
   }
 }
 
-static void parse_LD_SHIM_LIBS(const char* path) {
-  g_ld_all_shim_libs.clear();
+static void parse_shim_libs(const char* path) {
   if (path != nullptr) {
     // We have historically supported ':' as well as ' ' in LD_SHIM_LIBS.
     for (const auto& pair : android::base::Split(path, " :")) {
@@ -1271,6 +1270,14 @@ static void parse_LD_SHIM_LIBS(const char* path) {
     }
   }
   reset_g_active_shim_libs();
+}
+
+static void parse_LD_SHIM_LIBS(const char* path) {
+  g_ld_all_shim_libs.clear();
+#ifdef FORCED_SHIM_LIBS
+  parse_shim_libs(FORCED_SHIM_LIBS);
+#endif
+  parse_shim_libs(path);
 }
 
 template<typename F>


### PR DESCRIPTION
There are certain contexts in which the environment is cleansed.
Two examples that I know of are gps processes and mali gles blobs.

Generally, it is a better idea to use the environment variable because
then you can customize it on a per-service / script level and it is
easier to test and debug changes on the fly.

However, to avoid having libdimytry hexedit these blobs, allow a
last resort device level forced list of shim libraries.

Change-Id: I2f6aff9325beb5aa2f748bf72e6c3c0535d5aac2